### PR TITLE
l10n: add zh-Hant translation and remove spacing between English and CJK character

### DIFF
--- a/Activate/main.m
+++ b/Activate/main.m
@@ -143,12 +143,15 @@
     NSUserDefaults *defs = [NSUserDefaults standardUserDefaults];
     NSArray *languages = [defs objectForKey:@"AppleLanguages"];
     NSString *dLanguage = [languages objectAtIndex:0];
+    
+    // macOS' localization prefers to not add spacing between text,
+    // as it has built-in 1/4 spacing between Chinese and English character.
     if ([dLanguage isEqualToString:@"zh-Hans"] || [dLanguage isEqualToString:@"zh-Hans-CN"]) {
-        return @[@"激活 macOS", @"您当前所使用的可能是盗版 macOS 副本，请前往偏好设置激活。"];
+        return @[@"激活macOS", @"您当前所使用的可能是盗版macOS副本，请前往偏好设置激活。"];
     } else if ([dLanguage isEqualToString:@"zh-Hant"] || [dLanguage isEqualToString:@"zh-Hant-TW"]) {
-        return @[@"啟用 macOS", @"您目前使用的可能是盜版 macOS 副本。請前往「系統偏好設定」啟用。"];
+        return @[@"啟用macOS", @"您目前使用的可能是盜版macOS副本。請前往「系統偏好設定」啟用。"];
     } else if ([dLanguage isEqualToString:@"ja-JP"]) {
-        return @[@"macOS をアクティブ化", @"「システム環境設定」アクティブ化に行ってください。"];
+        return @[@"macOSをアクティブ化", @"「システム環境設定」アクティブ化に行ってください。"];
     } else {
         NSLog(@"Language: %@\n", dLanguage);
         return @[@"Activate macOS", @"Go to System Preferences to activate macOS."];

--- a/Activate/main.m
+++ b/Activate/main.m
@@ -145,6 +145,8 @@
     NSString *dLanguage = [languages objectAtIndex:0];
     if ([dLanguage isEqualToString:@"zh-Hans"] || [dLanguage isEqualToString:@"zh-Hans-CN"]) {
         return @[@"激活 macOS", @"您当前所使用的可能是盗版 macOS 副本，请前往偏好设置激活。"];
+    } else if ([dLanguage isEqualToString:@"zh-Hant"] || [dLanguage isEqualToString:@"zh-Hant-TW"]) {
+        return @[@"啟用 macOS", @"您目前使用的可能是盜版 macOS 副本。請前往「系統偏好設定」啟用。"];
     } else if ([dLanguage isEqualToString:@"ja-JP"]) {
         return @[@"macOS をアクティブ化", @"「システム環境設定」アクティブ化に行ってください。"];
     } else {


### PR DESCRIPTION
<div align="center">
  <img width="600" alt="從 
5b24577 組建的繁體中文翻譯" src="https://user-images.githubusercontent.com/28441561/170086906-71ecbb48-35f5-4c30-b225-0546290032a3.png">
  <img width="600" alt="從 
5b24577 組建的日文翻譯" src="https://user-images.githubusercontent.com/28441561/170086923-c34fb9bc-2d75-46c0-a9db-9297ba43dc8a.png">
</div>

## 變更摘要

- 加入 zh-Hant / zh-Hant-TW（繁體中文）的翻譯
- 移除中英文之間的手動補間

## 為什麼要移除中英文之間的手動補間？

### 論點

- macOS 的文字排版系統（包括 `NSAttributedString`）已經強大到內建中英文自動補 1/4 間距的功能了。
- 比起傳統的手動補間（1/2 補間），1/4 間距更加符合慣例的設計排版習慣。
- 不只 macOS，Microsoft Office 亦有內建補 1/4 間距的功能。
- 各大專業排版軟體皆有提供此功能 (availbility)。

### macOS 的本地化習慣是什麼？

#### macOS 系統內部 CJK: 繁體與簡體中文

繁體中文和簡體中文，基本上都是將補間的任務 **交給系統處理**。

<img width="1022" alt="macOS Catalina 官方之繁體中文翻譯詞彙庫的 “About this Mac” 翻譯。" src="https://user-images.githubusercontent.com/28441561/170084226-cc5aa5b3-b3a3-4bd0-8fe1-5d155be9cef6.png">

![macOS Catalina 官方之簡體中文翻譯詞彙庫的 iCloud / Apple TV 相關翻譯。](https://user-images.githubusercontent.com/28441561/170084832-6632a8dd-8662-4e88-a732-d0e0d4689069.png)

#### macOS 系統內部 CJK: 日文

日文亦將補間的任務 **交給系統處理**。

![macOS Catalina 官方之日文翻譯詞彙庫的 “About this Mac” 翻譯。](https://user-images.githubusercontent.com/28441561/170085074-b75705ca-7a72-4e57-bd53-66814cc1fbc4.png)

#### Apple 的網頁翻譯

值得注意的，是在不支援自動補間的場景（如網頁），Apple 的本地化仍然會傾向加上空白。因此翻譯補間仍然是 Apple 的慣例，惟支援自動補間之環境不手動補間。

<img width="1116" alt="Apple 官方網頁註解文字的 innerHTML 說明有空白。" src="https://user-images.githubusercontent.com/28441561/170085315-e6a656d7-7ebd-4c40-8b15-1e2b3ef4e556.png">
