### PR TITLE
l10n: add zh-Hant translation

### DIFF
--- a/Activate/main.m
+++ b/Activate/main.m
@@ -145,6 +145,8 @@
     NSString *dLanguage = [languages objectAtIndex:0];
     if ([dLanguage isEqualToString:@"zh-Hans"] || [dLanguage isEqualToString:@"zh-Hans-CN"]) {
         return @[@"激活 macOS", @"您当前所使用的可能是盗版 macOS 副本，请前往偏好设置激活。"];
+    } else if ([dLanguage isEqualToString:@"zh-Hant"] || [dLanguage isEqualToString:@"zh-Hant-TW"]) {
+        return @[@"啟用 macOS", @"您目前使用的可能是盜版 macOS 副本。請前往「系統偏好設定」啟用。"];
     } else if ([dLanguage isEqualToString:@"ja-JP"]) {
         return @[@"macOS をアクティブ化", @"「システム環境設定」アクティブ化に行ってください。"];
     } else {


### PR DESCRIPTION
Based on https://github.com/Lakr233/ActivateMac/pull/4, but with spacing between English and CJK characters.