### PR TITLE
I10n: add pl-PL translation

### DIFF
--- a/Activate/main.m
+++ b/Activate/main.m
@@ -149,6 +149,8 @@
         return @[@"啟用 macOS", @"您目前使用的可能是盜版 macOS 副本。請前往「系統偏好設定」啟用。"];
     } else if ([dLanguage isEqualToString:@"ja-JP"]) {
         return @[@"macOS をアクティブ化", @"「システム環境設定」アクティブ化に行ってください。"];
+    } else if ([dLanguage isEqualToString:@"pl-PL"]) {
+        return @[@"Aktywuj system macOS", @"Przejdź do ustawień, aby aktywować system macOS."];
     } else {
         NSLog(@"Language: %@\n", dLanguage);
         return @[@"Activate macOS", @"Go to System Preferences to activate macOS."];


### PR DESCRIPTION
pl-PL translation :)

<img width="569" alt="activate macOS in pl-PL" src="https://user-images.githubusercontent.com/9150636/170419524-4e033c29-a517-442f-8476-059442d7c72d.png">

![activate windows in pl-PL](https://ntt.pl/wp-content/uploads/2019/04/NTT-aktywacja-windows10-1024x455.png)