### PR TITLE
Add translations for German and Turkish

### DIFF
--- a/Activate/main.m
+++ b/Activate/main.m
@@ -153,6 +153,10 @@
         return @[@"Aktywuj system macOS", @"Przejdź do ustawień, aby aktywować system macOS."];
     } else if ([dLanguage isEqualToString:@"ru-RU"]) {
         return @[@"Активация macOS", @"Чтобы активировать macOS, перейдите в раздел \"Параметры\"."];
+    } else if ([dLanguage isEqualToString:@"de-DE"]) {
+        return @[@"macOS aktivieren", @"Wechseln Sie zu den Systemeinstellungen, um macOS zu aktivieren."];
+    } else if ([dLanguage isEqualToString:@"tr-TR"]) {
+        return @[@"macOS'i Etkinleştir", @"macOS'i etkinleştirmek için Ayarlar'a gidin."];
     } else {
         NSLog(@"Language: %@\n", dLanguage);
         return @[@"Activate macOS", @"Go to System Preferences to activate macOS."];


### PR DESCRIPTION
This is literally untested, as I do not have a computer with macOS installed. It should work regardless of that, because not much was changed.