### PR TITLE
Display the window on all spaces

### DIFF
--- a/Activate/main.m
+++ b/Activate/main.m
@@ -88,7 +88,7 @@
     [self setBackgroundColor:[NSColor clearColor]];
     [self setIgnoresMouseEvents:YES];
     [self setMovable:NO];
-    [self setCollectionBehavior:NSWindowCollectionBehaviorFullScreenAuxiliary | NSWindowCollectionBehaviorStationary];
+    [self setCollectionBehavior:NSWindowCollectionBehaviorFullScreenAuxiliary | NSWindowCollectionBehaviorStationary | NSWindowCollectionBehaviorCanJoinAllSpaces];
     [self setLevel:kCGStatusWindowLevel];
     [self setHasShadow:NO];
     return self;
@@ -103,7 +103,7 @@
 }
 
 - (NSWindowCollectionBehavior)collectionBehavior {
-    return NSWindowCollectionBehaviorFullScreenAuxiliary | NSWindowCollectionBehaviorStationary;
+    return NSWindowCollectionBehaviorFullScreenAuxiliary | NSWindowCollectionBehaviorStationary | NSWindowCollectionBehaviorCanJoinAllSpaces;
 }
 
 @end


### PR DESCRIPTION
This pull request adds the [NSWindowCollectionBehaviorCanJoinAllSpaces](https://developer.apple.com/documentation/appkit/nswindowcollectionbehavior/nswindowcollectionbehaviorcanjoinallspaces?language=objc) attribute to the collection behavior. This makes the activation message show up on all spaces instead of just the space that was active on launch.